### PR TITLE
Introduce MTF/RLE flag in BWT compressor

### DIFF
--- a/include/compression/BwtCompressor.hpp
+++ b/include/compression/BwtCompressor.hpp
@@ -57,11 +57,15 @@ public:
     /**
      * @brief Compresses data using the BWT algorithm
      * 
+     * The output format begins with the bytes "BWT", a version byte and a
+     * flags byte. Flag bit 0 indicates whether the block was further encoded
+     * with MTF/RLE/Huffman.
+     *
      * The compression pipeline is:
      * 1. Burrows-Wheeler Transform
      * 2. Move-To-Front Transform
-     * 3. Run-Length Encoding (optional)
-     * 4. Entropy coding (typically Huffman or Arithmetic)
+     * 3. Run-Length Encoding
+     * 4. Entropy coding (typically Huffman)
      * 
      * @param data The data to compress
      * @return The compressed data
@@ -71,9 +75,11 @@ public:
     /**
      * @brief Decompresses data that was compressed with the BWT algorithm
      * 
-     * The decompression pipeline is the reverse of compression:
+     * The decompression pipeline is the reverse of compression. If the
+     * header flag indicates no transformations were used, only the inverse
+     * Burrows-Wheeler Transform is applied. Otherwise:
      * 1. Entropy decoding
-     * 2. Run-Length decoding (if used)
+     * 2. Run-Length decoding
      * 3. Move-To-Front decoding
      * 4. Inverse Burrows-Wheeler Transform
      * 

--- a/include/compression/FileFormat.hpp
+++ b/include/compression/FileFormat.hpp
@@ -17,6 +17,10 @@ constexpr std::array<uint8_t, 4> MAGIC_NUMBER = {
 };
 constexpr uint8_t FORMAT_VERSION = 1;
 
+// --- BWT specific flags ---
+// Bit 0 set if the data block was entropy encoded after BWT (MTF/RLE/Huffman)
+constexpr uint8_t BWT_FLAG_TRANSFORMED = 0x01;
+
 // Algorithm IDs (extend this as new algorithms are added)
 enum class AlgorithmID : uint8_t {
     NULL_COMPRESSOR = 0,

--- a/src/BwtCompressor.cpp
+++ b/src/BwtCompressor.cpp
@@ -1,5 +1,6 @@
 #include "compression/BwtCompressor.hpp"
 #include "compression/HuffmanCompressor.hpp"
+#include "compression/FileFormat.hpp"
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>
@@ -347,12 +348,18 @@ std::vector<uint8_t> BwtCompressor::compress(const std::vector<uint8_t>& data) c
     result.reserve(data.size()); // Reserve space for worst case
     
     // Header: [B][W][T][version][flags]
-    // Where version = 1, flags bit 0 = RLE enabled, bit 1-7 reserved
+    // Where version = 1,
+    //       flags bit 0 = data was transformed with MTF/RLE/Huffman
     result.push_back('B');
     result.push_back('W');
     result.push_back('T');
     result.push_back(1); // Version 1
-    result.push_back(1); // Flags: RLE enabled
+    uint8_t flags = 0;
+    bool useTransforms = data.size() >= 10;
+    if (useTransforms) {
+        flags |= format::BWT_FLAG_TRANSFORMED;
+    }
+    result.push_back(flags);
     
     // For very small inputs, process as a single block without further compression
     if (data.size() < 10) {
@@ -466,7 +473,7 @@ std::vector<uint8_t> BwtCompressor::decompress(const std::vector<uint8_t>& data)
         throw std::runtime_error("Unsupported BWT version: " + std::to_string(version));
     }
     
-    bool rleEnabled = (flags & 1) != 0;
+    bool transformed = (flags & format::BWT_FLAG_TRANSFORMED) != 0;
     
     std::vector<uint8_t> result;
     size_t pos = 5; // Start after header
@@ -497,23 +504,22 @@ std::vector<uint8_t> BwtCompressor::decompress(const std::vector<uint8_t>& data)
         std::vector<uint8_t> compressedBlock(data.begin() + pos, data.begin() + pos + blockSize);
         pos += blockSize;
         
-        // For very small blocks, they might be stored directly without additional compression
-        if (blockSize <= 10 && compressedBlock.size() == blockSize) {
-            // Apply inverse BWT directly
+        if (!transformed) {
+            // Block stored as plain BWT output without further compression
             auto decodedBlock = bwtDecode(compressedBlock, primaryIndex);
             result.insert(result.end(), decodedBlock.begin(), decodedBlock.end());
             continue;
         }
-        
+
         // Apply entropy decoding (Huffman)
         auto entropyDecodedBlock = entropyCompressor_->decompress(compressedBlock);
-        
-        // Apply Run-Length Decoding if enabled
-        auto rleDecodedBlock = rleEnabled ? runLengthDecode(entropyDecodedBlock) : entropyDecodedBlock;
-        
+
+        // Apply Run-Length Decoding
+        auto rleDecodedBlock = runLengthDecode(entropyDecodedBlock);
+
         // Apply Move-To-Front decoding
         auto mtfDecodedBlock = mtfCoder_.decode(rleDecodedBlock);
-        
+
         // Apply inverse Burrows-Wheeler Transform
         auto bwtDecodedBlock = bwtDecode(mtfDecodedBlock, primaryIndex);
         


### PR DESCRIPTION
## Summary
- add `BWT_FLAG_TRANSFORMED` constant to the file format
- include new flag when compressing BWT blocks
- decode blocks using the flag instead of a size heuristic
- document the new flag in the BWT compressor header

## Testing
- `cmake ..`
- `cmake --build .`
- `./tests/compression_tests`

------
https://chatgpt.com/codex/tasks/task_e_6845b2e5cfdc832fb790538c632f69a2