### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Build and Deploy Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-14]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential cmake
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew update
+        brew install cmake
+
+    - name: Install dependencies (Windows)
+      if: runner.os == 'Windows'
+      run: choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+
+    - name: Configure
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      shell: bash
+
+    - name: Build
+      run: cmake --build build --config Release
+      shell: bash
+
+    - name: Install
+      run: cmake --install build --prefix package
+      shell: bash
+
+    - name: Archive
+      run: tar -czf compressor-${{ runner.os }}.tar.gz -C package .
+      shell: bash
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: compressor-${{ runner.os }}
+        path: compressor-${{ runner.os }}.tar.gz
+
+  deploy:
+    name: Upload Release Assets
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+
+    - name: Publish assets
+      uses: softprops/action-gh-release@v1
+      with:
+        files: dist/**/compressor-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Compression Library
 
+[![Build and Test](https://github.com/yourusername/compressor/actions/workflows/build-test.yml/badge.svg)](https://github.com/yourusername/compressor/actions/workflows/build-test.yml)
+[![Release](https://github.com/yourusername/compressor/actions/workflows/release.yml/badge.svg)](https://github.com/yourusername/compressor/actions/workflows/release.yml)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+
 A high-performance file compression library implemented in C++ that provides multiple compression algorithms with a focus on achieving excellent compression ratios for files at rest.
 
 ## Features


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy artifacts on release
- display build and release badges in the README

## Testing
- `cmake .. && cmake --build . --config Release && ctest --output-on-failure -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_686d425de590832f85e206c3a0bf54ad