### PR TITLE
Fix Windows release install configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       shell: bash
 
     - name: Install
-      run: cmake --install build --prefix package
+      run: cmake --install build --config Release --prefix package
       shell: bash
 
     - name: Archive


### PR DESCRIPTION
## Summary
- fix the install step in `release.yml` to specify the Release configuration

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `ctest --output-on-failure --verbose`
- `./app/compression_benchmark`

------
https://chatgpt.com/codex/tasks/task_e_686d5cb58dc8832f9a8f91161880b487