### PR TITLE
Improve LZ77 stream encoding and validation

### DIFF
--- a/include/compression/Lz77Compressor.hpp
+++ b/include/compression/Lz77Compressor.hpp
@@ -38,7 +38,7 @@ public:
         uint8_t literal = 0;         // Literal value
         
         bool isLiteral() const { return symbol < 256; }
-        bool isLength() const { return symbol >= 257 && symbol <= 285; }
+        bool isLength() const { return symbol >= LENGTH_CODE_BASE; }
         bool isEob() const { return symbol == EOB_SYMBOL; }
     };
     

--- a/src/Lz77Compressor.cpp
+++ b/src/Lz77Compressor.cpp
@@ -300,98 +300,155 @@ std::vector<Lz77Compressor::Lz77Symbol> Lz77Compressor::compressToSymbols(const 
     return symbols;
 }
 
-// Encode symbols with a much more efficient bit-packed format
+// Encode symbols using block flags so that literals can represent all 256 values
+// and matches are stored compactly without sentinel bytes that conflict with literals.
 std::vector<uint8_t> Lz77Compressor::encodeSymbols(const std::vector<Lz77Symbol>& symbols) const {
     if (symbols.empty()) return {};
-    
+
+    // We write the number of symbols up front so the decoder knows when to stop
+    // even when the final flag byte is only partially full.
     std::vector<uint8_t> result;
-    // Reserve conservatively to avoid reallocations
-    result.reserve(symbols.size());
-    
+    result.resize(4, 0); // Placeholder for symbol count (little endian)
+
+    uint32_t symbolCount = 0;
+    uint8_t flagByte = 0;
+    uint8_t flagCount = 0;
+    std::vector<uint8_t> blockData;
+    blockData.reserve(8 * 3);
+
+    const auto flushBlock = [&](std::vector<uint8_t>& out) {
+        out.push_back(flagByte);
+        out.insert(out.end(), blockData.begin(), blockData.end());
+    };
+
     for (const auto& symbol : symbols) {
-        if (symbol.isLiteral()) {
-            // For literals, directly output the byte (0-255)
-            result.push_back(static_cast<uint8_t>(symbol.symbol));
-        } else if (symbol.isLength()) {
-            // For matches, use a special format:
-            // First byte: 0xFF (marker)
-            // Second byte: length (up to 255)
-            // Next 2 bytes: distance (up to 65535)
-            
-            result.push_back(0xFF); // Marker for match
-            result.push_back(static_cast<uint8_t>(symbol.length));
-            
-            // Write distance (little endian)
-            result.push_back(static_cast<uint8_t>(symbol.distance & 0xFF));
-            result.push_back(static_cast<uint8_t>((symbol.distance >> 8) & 0xFF));
+        if (symbol.isEob()) {
+            continue; // We don't encode EOB for this format
         }
-        // EOB is implicitly the end of the data
+
+        bool isMatch = symbol.isLength();
+        if (isMatch) {
+            if (symbol.length < minMatchLength_ || symbol.length > maxMatchLength_) {
+                throw std::runtime_error("Invalid match length while encoding LZ77 stream");
+            }
+
+            if (symbol.length - 3 > std::numeric_limits<uint8_t>::max()) {
+                throw std::runtime_error("Match length exceeds encodable range");
+            }
+
+            if (symbol.distance == 0 || symbol.distance > windowSize_) {
+                throw std::runtime_error("Invalid match distance while encoding LZ77 stream");
+            }
+
+            if (symbol.distance - 1 > std::numeric_limits<uint16_t>::max()) {
+                throw std::runtime_error("Match distance exceeds encodable range");
+            }
+
+            uint16_t distanceValue = static_cast<uint16_t>(symbol.distance - 1);
+            uint8_t lengthValue = static_cast<uint8_t>(symbol.length - 3);
+
+            blockData.push_back(lengthValue);
+            blockData.push_back(static_cast<uint8_t>(distanceValue & 0xFF));
+            blockData.push_back(static_cast<uint8_t>((distanceValue >> 8) & 0xFF));
+
+            flagByte |= static_cast<uint8_t>(1u << flagCount);
+        } else {
+            blockData.push_back(static_cast<uint8_t>(symbol.literal));
+        }
+
+        flagCount++;
+        symbolCount++;
+
+        if (flagCount == 8) {
+            flushBlock(result);
+            flagByte = 0;
+            flagCount = 0;
+            blockData.clear();
+        }
     }
-    
+
+    if (flagCount > 0) {
+        flushBlock(result);
+    }
+
+    result[0] = static_cast<uint8_t>(symbolCount & 0xFF);
+    result[1] = static_cast<uint8_t>((symbolCount >> 8) & 0xFF);
+    result[2] = static_cast<uint8_t>((symbolCount >> 16) & 0xFF);
+    result[3] = static_cast<uint8_t>((symbolCount >> 24) & 0xFF);
+
     return result;
 }
 
-// Update decompress to match the new encoding format and add stricter validation
+// Decode the block-flagged format. Fail fast on malformed data instead of masking errors.
 std::vector<uint8_t> Lz77Compressor::decompress(const std::vector<uint8_t>& data) const {
     if (data.empty()) return {};
-    
+
+    if (data.size() < 4) {
+        throw std::runtime_error("Compressed LZ77 stream truncated before symbol count");
+    }
+
+    uint32_t expectedSymbols = static_cast<uint32_t>(data[0]) |
+        (static_cast<uint32_t>(data[1]) << 8) |
+        (static_cast<uint32_t>(data[2]) << 16) |
+        (static_cast<uint32_t>(data[3]) << 24);
+
     std::vector<uint8_t> result;
-    // Pre-allocate some space to reduce reallocations
-    result.reserve(data.size() * 2);
-    
-    size_t i = 0;
-    while (i < data.size()) {
-        uint8_t currentByte = data[i++];
-        
-        if (currentByte == 0xFF) {
-            // This is a match pattern (marker 0xFF)
-            // Check for truncated data
-            if (i + 2 >= data.size()) {
-                // Handle truncated data by adding placeholder characters
-                // Add 1-3 placeholder characters
-                for (size_t j = 0; j < 3 && i + j < data.size(); j++) {
-                    result.push_back('?');
+    result.reserve(std::max<std::size_t>(data.size() * 2, 64));
+
+    size_t offset = 4;
+    uint32_t decodedSymbols = 0;
+
+    while (decodedSymbols < expectedSymbols) {
+        if (offset >= data.size()) {
+            throw std::runtime_error("Compressed LZ77 stream truncated before flag byte");
+        }
+
+        uint8_t flagByte = data[offset++];
+
+        for (uint8_t bit = 0; bit < 8 && decodedSymbols < expectedSymbols; ++bit) {
+            bool isMatch = (flagByte >> bit) & 0x1u;
+
+            if (isMatch) {
+                if (offset + 3 > data.size()) {
+                    throw std::runtime_error("Compressed LZ77 stream truncated in match data");
                 }
-                // Skip to the end since we can't properly decode this
-                break;
-            }
-            
-            // Read length (1 byte)
-            uint8_t length = data[i++];
-            
-            // Read distance (2 bytes, little endian)
-            uint16_t distanceLow = data[i++];
-            uint16_t distanceHigh = 0;
-            
-            if (i < data.size()) {
-                distanceHigh = data[i++];
-            }
-            
-            uint16_t distance = distanceLow | (distanceHigh << 8);
-            
-            // Validate distance and length
-            if (distance == 0 || distance > result.size()) {
-                // Instead of throwing an exception, treat this as a data corruption
-                // and output placeholder characters
-                for (size_t j = 0; j < length; j++) {
-                    result.push_back('?');
+
+                uint8_t lengthValue = data[offset++];
+                uint16_t distanceValue = static_cast<uint16_t>(data[offset++]);
+                distanceValue |= static_cast<uint16_t>(data[offset++]) << 8;
+
+                size_t length = static_cast<size_t>(lengthValue) + 3;
+                size_t distance = static_cast<size_t>(distanceValue) + 1;
+
+                if (length < minMatchLength_ || length > maxMatchLength_) {
+                    throw std::runtime_error("Invalid match length in LZ77 stream");
                 }
-                continue;
+
+                if (distance == 0 || distance > windowSize_) {
+                    throw std::runtime_error("Invalid match distance in LZ77 stream");
+                }
+
+                if (distance > result.size()) {
+                    throw std::runtime_error("Match distance exceeds produced output");
+                }
+
+                size_t startPos = result.size() - distance;
+                for (size_t j = 0; j < length; ++j) {
+                    uint8_t byte = result[startPos + (j % distance)];
+                    result.push_back(byte);
+                }
+            } else {
+                if (offset >= data.size()) {
+                    throw std::runtime_error("Compressed LZ77 stream truncated in literal data");
+                }
+
+                result.push_back(data[offset++]);
             }
-            
-            // Copy bytes from the output buffer
-            size_t startPos = result.size() - distance;
-            for (size_t j = 0; j < length; j++) {
-                // Handle overlapping copy correctly using modulo
-                uint8_t byte = result[startPos + (j % distance)];
-                result.push_back(byte);
-            }
-        } else {
-            // This is a literal byte
-            result.push_back(currentByte);
+
+            decodedSymbols++;
         }
     }
-    
+
     return result;
 }
 

--- a/tests/Lz77CompressorTest.cpp
+++ b/tests/Lz77CompressorTest.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdint> // For uint8_t
 #include <stdexcept>
+#include <limits>
 
 // Helper function to convert string to vector<uint8_t>
 static std::vector<uint8_t> stringToBytes(const std::string& str) {
@@ -163,7 +164,7 @@ TEST_F(Lz77CompressorTest, DataRequiresMaxDistance) {
 TEST_F(Lz77CompressorTest, DataRequiresMaxLength) {
     // Create a short string that will be directly copied
     std::string data = "ABC";
-    
+
     std::vector<uint8_t> bytes(data.begin(), data.end());
     std::vector<uint8_t> compressed = compressor.compress(bytes);
     std::vector<uint8_t> decompressed = compressor.decompress(compressed);
@@ -180,147 +181,158 @@ TEST_F(Lz77CompressorTest, DataRequiresMaxLength) {
 }
 
 
+TEST_F(Lz77CompressorTest, HandlesAllLiteralByteValues) {
+    std::vector<uint8_t> data(512);
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = static_cast<uint8_t>(i % 256);
+    }
+
+    auto compressed = compressor.compress(data);
+    auto decompressed = compressor.decompress(compressed);
+
+    EXPECT_EQ(decompressed, data);
+}
+
+TEST_F(Lz77CompressorTest, EncodesAndDecodesLongMatches) {
+    std::string original(400, 'Z');
+    auto data = stringToBytes(original);
+
+    auto compressed = compressor.compress(data);
+    auto decompressed = compressor.decompress(compressed);
+    EXPECT_EQ(decompressed, data);
+
+    // Ensure at least one encoded length uses the extended range (255 -> length 258)
+    uint32_t symbolCount = compressed[0] |
+        (compressed[1] << 8) |
+        (compressed[2] << 16) |
+        (compressed[3] << 24);
+
+    size_t offset = 4;
+    uint32_t processed = 0;
+    bool sawLongLength = false;
+    while (processed < symbolCount && offset < compressed.size()) {
+        uint8_t flags = compressed[offset++];
+        for (uint8_t bit = 0; bit < 8 && processed < symbolCount; ++bit) {
+            bool isMatch = (flags >> bit) & 0x1u;
+            if (isMatch) {
+                ASSERT_LE(offset + 3, compressed.size());
+                uint8_t lengthValue = compressed[offset];
+                if (lengthValue == std::numeric_limits<uint8_t>::max()) {
+                    sawLongLength = true;
+                }
+                offset += 3;
+            } else {
+                offset += 1;
+            }
+            processed++;
+            if (sawLongLength) {
+                break;
+            }
+        }
+        if (sawLongLength) {
+            break;
+        }
+    }
+
+    EXPECT_TRUE(sawLongLength);
+}
+
+
 // --- Decompression Error Tests ---
 
 TEST_F(Lz77CompressorTest, DecompressEmpty) {
-    // This is valid, should produce empty output
     std::vector<uint8_t> compressed = {};
     std::vector<uint8_t> decompressed = compressor.decompress(compressed);
     EXPECT_TRUE(decompressed.empty());
 }
 
-TEST_F(Lz77CompressorTest, DecompressTruncatedLiteralFlagOnly) {
-    // For a single 0xFF byte, we might get nothing or a placeholder
-    std::vector<uint8_t> compressed = {0xFF}; // Match marker with no data
-    std::vector<uint8_t> decompressed;
-    ASSERT_NO_THROW({ decompressed = compressor.decompress(compressed); });
-
-    bool allPlaceholders =
-        !decompressed.empty() &&
-        std::all_of(decompressed.begin(), decompressed.end(),
-                     [](uint8_t b) { return b == '?'; });
-
-    EXPECT_TRUE(decompressed.empty() || allPlaceholders);
+TEST_F(Lz77CompressorTest, DecompressTruncatedHeaderThrows) {
+    std::vector<uint8_t> compressed = {0x01, 0x00, 0x00};
+    EXPECT_THROW(compressor.decompress(compressed), std::runtime_error);
 }
 
-TEST_F(Lz77CompressorTest, DecompressTruncatedPairFlagOnly) {
-    std::vector<uint8_t> compressed = {0xFF}; // Match marker with no data
-    std::vector<uint8_t> decompressed;
-    ASSERT_NO_THROW({ decompressed = compressor.decompress(compressed); });
-
-    bool allPlaceholders =
-        !decompressed.empty() &&
-        std::all_of(decompressed.begin(), decompressed.end(),
-                     [](uint8_t b) { return b == '?'; });
-
-    EXPECT_TRUE(decompressed.empty() || allPlaceholders);
+TEST_F(Lz77CompressorTest, DecompressTruncatedLiteralThrows) {
+    std::string original = "Hello world";
+    auto compressed = compressor.compress(stringToBytes(original));
+    ASSERT_FALSE(compressed.empty());
+    compressed.pop_back();
+    EXPECT_THROW(compressor.decompress(compressed), std::runtime_error);
 }
 
-TEST_F(Lz77CompressorTest, DecompressTruncatedPairMissingLength) {
-    std::vector<uint8_t> compressed = {
-        0xFF, // Match marker
-        // Missing length and distance bytes
-    };
-    std::vector<uint8_t> decompressed;
-    ASSERT_NO_THROW({ decompressed = compressor.decompress(compressed); });
+TEST_F(Lz77CompressorTest, DecompressTruncatedMatchThrows) {
+    std::string original(64, 'A');
+    auto compressed = compressor.compress(stringToBytes(original));
+    ASSERT_FALSE(compressed.empty());
 
-    bool allPlaceholders =
-        !decompressed.empty() &&
-        std::all_of(decompressed.begin(), decompressed.end(),
-                     [](uint8_t b) { return b == '?'; });
+    // Walk the encoding to locate the first match payload and truncate it
+    uint32_t symbolCount = compressed[0] |
+        (compressed[1] << 8) |
+        (compressed[2] << 16) |
+        (compressed[3] << 24);
 
-    EXPECT_TRUE(decompressed.empty() || allPlaceholders);
+    size_t offset = 4;
+    uint32_t processed = 0;
+    bool truncated = false;
+    while (processed < symbolCount && offset < compressed.size()) {
+        uint8_t flags = compressed[offset++];
+        for (uint8_t bit = 0; bit < 8 && processed < symbolCount; ++bit) {
+            bool isMatch = (flags >> bit) & 0x1u;
+            if (isMatch) {
+                ASSERT_LE(offset + 3, compressed.size());
+                compressed.erase(compressed.begin() + offset); // remove length byte
+                truncated = true;
+                break;
+            } else {
+                offset += 1;
+            }
+            processed++;
+        }
+        if (truncated) {
+            break;
+        }
+    }
+
+    ASSERT_TRUE(truncated);
+    EXPECT_THROW(compressor.decompress(compressed), std::runtime_error);
 }
 
-TEST_F(Lz77CompressorTest, DecompressTruncatedPairMissingDistHigh) {
-    std::vector<uint8_t> compressed = {
-        0xFF, // Match marker
-        5,    // Length
-        10,   // Distance low byte
-        // Missing Distance high byte
-    };
-    std::vector<uint8_t> decompressed;
-    ASSERT_NO_THROW({ decompressed = compressor.decompress(compressed); });
+TEST_F(Lz77CompressorTest, DecompressInvalidDistanceThrows) {
+    std::string original(32, 'B');
+    auto compressed = compressor.compress(stringToBytes(original));
 
-    bool allPlaceholders =
-        !decompressed.empty() &&
-        std::all_of(decompressed.begin(), decompressed.end(),
-                     [](uint8_t b) { return b == '?'; });
+    uint32_t symbolCount = compressed[0] |
+        (compressed[1] << 8) |
+        (compressed[2] << 16) |
+        (compressed[3] << 24);
 
-    EXPECT_TRUE(decompressed.empty() || allPlaceholders);
+    size_t offset = 4;
+    uint32_t processed = 0;
+    bool modified = false;
+    while (processed < symbolCount && offset < compressed.size()) {
+        uint8_t flags = compressed[offset++];
+        for (uint8_t bit = 0; bit < 8 && processed < symbolCount; ++bit) {
+            bool isMatch = (flags >> bit) & 0x1u;
+            if (isMatch) {
+                ASSERT_LE(offset + 3, compressed.size());
+                // Leave length intact but set an impossible distance (larger than output)
+                offset += 1; // skip length
+                compressed[offset] = 0xFF;
+                compressed[offset + 1] = 0xFF;
+                modified = true;
+                break;
+            } else {
+                offset += 1;
+            }
+            processed++;
+        }
+        if (modified) {
+            break;
+        }
+    }
+
+    ASSERT_TRUE(modified);
+    EXPECT_THROW(compressor.decompress(compressed), std::runtime_error);
 }
-
-TEST_F(Lz77CompressorTest, DecompressInvalidFlag) {
-    // In our new format, any byte that's not 0xFF is a literal, so there are no invalid flags
-    std::vector<uint8_t> compressed = {
-        'A', // Literal 'A'
-        42,  // Literal byte with value 42
-        'B'  // Literal 'B'
-    };
-    std::vector<uint8_t> decompressed = compressor.decompress(compressed);
-    // This is now valid and should decompress to "A*B"
-    EXPECT_EQ(decompressed.size(), 3);
-    EXPECT_EQ(decompressed[0], 'A');
-    EXPECT_EQ(decompressed[1], 42);
-    EXPECT_EQ(decompressed[2], 'B');
-}
-
-TEST_F(Lz77CompressorTest, DecompressInvalidDistanceZero) {
-    // Compressed: Lit(A), Lit(B), Lit(C), Match(len=3, dist=0) <- Invalid distance
-    std::vector<uint8_t> compressed = {
-        'A', 'B', 'C',
-        0xFF, // Match marker
-        3,    // Length = 3
-        0, 0  // Distance = 0 (Invalid)
-    };
-    std::vector<uint8_t> decompressed = compressor.decompress(compressed);
-    // Should get "ABC???" or similar placeholder handling
-    EXPECT_EQ(decompressed.size(), 6);
-    EXPECT_EQ(decompressed[0], 'A');
-    EXPECT_EQ(decompressed[1], 'B');
-    EXPECT_EQ(decompressed[2], 'C');
-    // Next 3 bytes should be placeholders ('?')
-    EXPECT_EQ(decompressed[3], '?');
-    EXPECT_EQ(decompressed[4], '?');
-    EXPECT_EQ(decompressed[5], '?');
-}
-
-TEST_F(Lz77CompressorTest, DecompressInvalidDistanceTooLarge) {
-    // Compressed: Lit(A), Lit(B), Lit(C), Match(len=3, dist=5) <- Distance > decompressed size (3)
-    std::vector<uint8_t> compressed = {
-        'A', 'B', 'C',
-        0xFF, // Match marker
-        3,    // Length = 3
-        5, 0  // Distance = 5 (Invalid, only 3 bytes available)
-    };
-    std::vector<uint8_t> decompressed = compressor.decompress(compressed);
-    // Should get "ABC???" or similar placeholder handling
-    EXPECT_EQ(decompressed.size(), 6);
-    EXPECT_EQ(decompressed[0], 'A');
-    EXPECT_EQ(decompressed[1], 'B');
-    EXPECT_EQ(decompressed[2], 'C');
-    // Next 3 bytes should be placeholders ('?')
-    EXPECT_EQ(decompressed[3], '?');
-    EXPECT_EQ(decompressed[4], '?');
-    EXPECT_EQ(decompressed[5], '?');
-}
-
-// TEST_F(Lz77CompressorTest, DecompressInvalidLengthTooSmall) {
-//     // Note: The compressor shouldn't produce lengths < MIN_MATCH_LENGTH for pairs,
-//     // and the decompressor adds MIN_MATCH_LENGTH back, making this check unreachable
-//     // with the current encoding. Removing this test as it tests an impossible scenario
-//     // for the current implementation.
-//      std::vector<uint8_t> compressed = {
-//         0, static_cast<uint8_t>('A'),
-//         0, static_cast<uint8_t>('B'),
-//         0, static_cast<uint8_t>('C'),
-//         1,
-//         1, 0, // Distance = 1
-//         0 // Encoded Length = 0 -> Actual Length = 3 (Valid)
-//         // Cannot construct a case where encodedLen + MIN_MATCH_LENGTH < MIN_MATCH_LENGTH
-//     };
-//     // EXPECT_THROW(compressor.decompress(compressed), std::runtime_error);
-// } 
 
 TEST_F(Lz77CompressorTest, DISABLED_HandlesLongRepeatedSequence) {
     // ... existing code ...


### PR DESCRIPTION
## Summary
- replace the ad-hoc LZ77 byte marker with a flagged block format that preserves all literal values and supports long matches
- harden the decompressor to track symbol counts and throw when the stream is truncated or has impossible references
- expand the LZ77 unit tests to cover binary payloads, long match lengths, and failure cases for truncated or tampered data

## Testing
- ./build/tests/compression_tests --gtest_filter=Lz77CompressorTest.*


------
https://chatgpt.com/codex/tasks/task_e_68c910e2e094832fba595fdeb5bc8a52