### PR TITLE
feat: optimize arithmetic decoder, MTF, and remove dead code

### DIFF
--- a/include/compression/BwtCompressor.hpp
+++ b/include/compression/BwtCompressor.hpp
@@ -16,7 +16,6 @@ public:
 
 private:
     std::vector<uint8_t> bwt_transform(const std::vector<uint8_t>& data) const;
-    std::vector<uint8_t> bwt_transform_fast(const std::vector<uint8_t>& data) const;
     std::vector<uint8_t> inverse_bwt_transform(const std::vector<uint8_t>& data) const;
 
     static std::vector<uint8_t> mtf_encode(const std::vector<uint8_t>& data);

--- a/include/compression/OptimizedCompressor.hpp
+++ b/include/compression/OptimizedCompressor.hpp
@@ -14,17 +14,6 @@ class HuffmanCompressor;
 class BwtCompressor;
 
 /**
- * @struct DataCharacteristics
- * @brief Analysis results for input data characteristics
- */
-struct DataCharacteristics {
-  double entropy = 8.0;            // Data entropy (0-8 for bytes)
-  bool isHighlyRepetitive = false; // Low entropy, high repetition
-  bool hasLongRuns = false;        // Has long runs of identical bytes
-  bool hasLongMatches = false;     // Has good pattern matching potential
-};
-
-/**
  * @class OptimizedCompressor
  * @brief Intelligent compressor that adapts strategy based on data
  * characteristics
@@ -69,9 +58,6 @@ private:
   std::unique_ptr<Lz77Compressor> lz77_;
   std::unique_ptr<HuffmanCompressor> huffman_;
   std::unique_ptr<BwtCompressor> bwt_;
-
-  // Data analysis
-  DataCharacteristics analyzeData(const std::vector<uint8_t> &data) const;
 
   // Compression strategies
   std::vector<uint8_t>

--- a/include/compression/UltraCompressor.hpp
+++ b/include/compression/UltraCompressor.hpp
@@ -1,15 +1,17 @@
 #pragma once
-
+ 
 #include <compression/ICompressor.hpp>
 #include <memory>
 #include <vector>
 #include <cstdint>
-
+ 
 namespace compression {
-
+ 
 // Forward declarations
 class Lz77Compressor;
-
+class BwtCompressor;
+class OptimizedCompressor;
+ 
 /**
  * @class UltraCompressor
  * @brief Maximum compression ratio compressor using multi-stage approach
@@ -46,9 +48,12 @@ public:
      * @return Original decompressed data
      */
     std::vector<uint8_t> decompress(const std::vector<uint8_t>& data) const override;
-
+ 
 private:
-    std::unique_ptr<Lz77Compressor> lz77_;
+    mutable std::unique_ptr<Lz77Compressor> lz77_;
+    mutable std::unique_ptr<BwtCompressor> bwt_;
+    mutable std::unique_ptr<OptimizedCompressor> optimized_;
 };
-
+ 
 } // namespace compression
+

--- a/src/ArithmeticCompressor.cpp
+++ b/src/ArithmeticCompressor.cpp
@@ -189,50 +189,25 @@ uint8_t ArithmeticCompressor::AdaptiveContextModel::getSymbol(
   const auto &ctx = contexts_[context];
   total = ctx.total;
 
-  // Binary search over prefix sums for O(log N) would be ideal,
-  // but linear scan over 256 items is ~100-200 ops, totally fine for now
-  // compared to Range Coder arithmetic.
-  uint32_t current_low = 0;
-  for (int i = 0; i < 256; ++i) {
-    // query(ctx, i+1) gives cumulative up to i
-    // Optimization: track cumulative sum linearly
-    // Wait, 'query' is O(log N). 256 * log N is slow.
-    // We really just need to traverse.
-    // Since we treat Fenwick indices 1..256, but we can't iterate efficiently
-    // without rebuilding. Let's use `query` but binary search? Or just optimize
-    // later. Let's rely on `query` for correctness first, even if O(256 * 8).
-    // It's 2k ops. Might be bottleneck.
-
-    // BETTER: maintain a cached 'tree' or just use the Fenwick structure to
-    // binary lift. Implementing Binary Lifting on Fenwick Tree for O(log N): We
-    // search for index 'idx' such that query(idx-1) <= count < query(idx).
-
-    // Standard Binary Lifting on BIT
-    /*
+ // Binary lifting on Fenwick tree for O(log N) symbol lookup.
+    // Finds largest idx such that query(idx) <= count.
+    // Symbol is idx (0-based: idx=0 -> symbol 0, idx=1 -> symbol 1, ...).
     int idx = 0;
-    int sum = 0;
+    int32_t accumulated = 0;
     for (int bit_mask = 128; bit_mask > 0; bit_mask >>= 1) {
-        int tIdx = idx + bit_mask;
-        if (tIdx < 257 && sum + ctx.tree[tIdx] <= count) {
-            idx = tIdx;
-            sum += ctx.tree[idx];
-        }
+      int tIdx = idx + bit_mask;
+      if (tIdx < 257 &&
+          accumulated + ctx.tree[static_cast<size_t>(tIdx)] <=
+              static_cast<int32_t>(count)) {
+        idx = tIdx;
+        accumulated +=
+            static_cast<int32_t>(ctx.tree[static_cast<size_t>(idx)]);
+      }
     }
-    return idx; // idx is 0-255? No, BIT is 1-based.
-    */
-
-    // Let's stick to safe Linear Scan for correctness first, straightforward
-    // debug.
-    uint32_t sym_freq = query(ctx, i + 1) - query(ctx, i);
-    if (current_low + sym_freq > count) {
-      low = current_low;
-      high = current_low + sym_freq;
-      return static_cast<uint8_t>(i);
-    }
-    current_low += sym_freq;
-  }
-  // Should not reach here if count < total
-  return 0;
+    uint32_t symIdx = static_cast<uint32_t>(idx);
+    low = static_cast<uint32_t>(accumulated);
+    high = query(ctx, idx + 1);
+    return static_cast<uint8_t>(symIdx);
 }
 
 // --- Range Encoder ---

--- a/src/BwtCompressor.cpp
+++ b/src/BwtCompressor.cpp
@@ -9,15 +9,6 @@
 
 namespace compression {
 
-// Helper to write a 32-bit integer to a byte vector in big-endian format.
-void write_u32_be(std::vector<uint8_t> &dest, uint32_t value) {
-  dest.push_back(static_cast<uint8_t>((value >> 24) & 0xFF));
-  dest.push_back(static_cast<uint8_t>((value >> 16) & 0xFF));
-  dest.push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
-  dest.push_back(static_cast<uint8_t>(value & 0xFF));
-}
-
-// Helper to read a 32-bit integer from a byte vector in big-endian format.
 uint32_t read_u32_be(const std::vector<uint8_t> &src, size_t &pos) {
   if (pos + 4 > src.size()) {
     throw std::out_of_range("read_u32_be: insufficient bytes");
@@ -28,6 +19,8 @@ uint32_t read_u32_be(const std::vector<uint8_t> &src, size_t &pos) {
   uint32_t b3 = static_cast<uint32_t>(src[pos++]);
   return (b0 << 24) | (b1 << 16) | (b2 << 8) | b3;
 }
+
+
 
 std::vector<uint8_t>
 BwtCompressor::compress(const std::vector<uint8_t> &data) const {
@@ -260,8 +253,7 @@ BwtCompressor::mtf_encode(const std::vector<uint8_t> &data) {
     result.push_back(static_cast<uint8_t>(rank));
 
     // Move symbol to front
-    symbol_table.erase(it);
-    symbol_table.insert(symbol_table.begin(), symbol);
+    std::rotate(symbol_table.begin(), it, it + 1);
   }
   return result;
 }
@@ -282,8 +274,7 @@ BwtCompressor::mtf_decode(const std::vector<uint8_t> &data) {
     result.push_back(symbol);
 
     // Move symbol to front
-    symbol_table.erase(symbol_table.begin() + rank);
-    symbol_table.insert(symbol_table.begin(), symbol);
+    std::rotate(symbol_table.begin(), symbol_table.begin() + rank, symbol_table.begin() + rank + 1);
   }
   return result;
 }

--- a/src/OptimizedCompressor.cpp
+++ b/src/OptimizedCompressor.cpp
@@ -22,9 +22,6 @@ OptimizedCompressor::compress(const std::vector<uint8_t> &data) const {
     return {};
   }
 
-  // Analyze data characteristics to choose optimal strategy
-  DataCharacteristics characteristics = analyzeData(data);
-
   // Try all strategies and pick the best one
   std::vector<uint8_t> bestResult;
 
@@ -114,68 +111,7 @@ OptimizedCompressor::decompress(const std::vector<uint8_t> &data) const {
   }
 }
 
-DataCharacteristics
-OptimizedCompressor::analyzeData(const std::vector<uint8_t> &data) const {
-  DataCharacteristics characteristics;
 
-  if (data.size() < 100) {
-    characteristics.entropy = 8.0;
-    return characteristics; // Too small for meaningful analysis
-  }
-
-  // Calculate entropy
-  std::array<size_t, 256> freq{};
-  for (uint8_t byte : data) {
-    freq[byte]++;
-  }
-
-  double entropy = 0.0;
-  for (size_t count : freq) {
-    if (count > 0) {
-      double p = static_cast<double>(count) / data.size();
-      entropy -= p * std::log2(p);
-    }
-  }
-
-  characteristics.entropy = entropy;
-  characteristics.isHighlyRepetitive = (entropy < 6.0);
-
-  // Check for long repeated sequences
-  size_t maxRun = 1;
-  size_t currentRun = 1;
-  for (size_t i = 1; i < data.size(); ++i) {
-    if (data[i] == data[i - 1]) {
-      currentRun++;
-    } else {
-      maxRun = std::max(maxRun, currentRun);
-      currentRun = 1;
-    }
-  }
-  maxRun = std::max(maxRun, currentRun);
-
-  characteristics.hasLongRuns = (maxRun > 10);
-
-  // Check for pattern matches (simplified)
-  std::map<std::vector<uint8_t>, size_t> patterns;
-  const size_t patternLength = 4;
-
-  for (size_t i = 0; i + patternLength <= data.size(); ++i) {
-    std::vector<uint8_t> pattern(data.begin() + i,
-                                 data.begin() + i + patternLength);
-    patterns[pattern]++;
-  }
-
-  size_t repeatedPatterns = 0;
-  for (const auto &[pattern, count] : patterns) {
-    if (count > 1) {
-      repeatedPatterns++;
-    }
-  }
-
-  characteristics.hasLongMatches = (repeatedPatterns > patterns.size() * 0.1);
-
-  return characteristics;
-}
 
 std::vector<uint8_t> OptimizedCompressor::compressRepetitiveData(
     const std::vector<uint8_t> &data) const {

--- a/src/UltraCompressor.cpp
+++ b/src/UltraCompressor.cpp
@@ -6,56 +6,56 @@
 #include <iostream>
 #include <stdexcept>
 #include <utility>
-
+ 
 namespace compression {
-
+ 
 UltraCompressor::UltraCompressor() 
-    : lz77_(std::make_unique<Lz77Compressor>(65536, 3, 258, false, true, true)) {
+    : lz77_(std::make_unique<Lz77Compressor>(65536, 3, 258, false, true, true)),
+      bwt_(std::make_unique<BwtCompressor>()),
+      optimized_(std::make_unique<OptimizedCompressor>()) {
 }
-
+ 
 UltraCompressor::~UltraCompressor() = default;
-
+ 
 std::vector<uint8_t> UltraCompressor::compress(const std::vector<uint8_t>& data) const {
     if (data.empty()) {
         return {};
     }
-
+ 
     std::cout << "🔄 Stage 1: BWT transform..." << std::endl;
-    BwtCompressor bwt;
-    auto bwt_transformed = bwt.transform(data);
-
+    auto bwt_transformed = bwt_->transform(data);
+ 
     std::cout << "🔄 Stage 2: LZ77 on BWT..." << std::endl;
     auto lz77_compressed = lz77_->compress(bwt_transformed);
-
+ 
     // No outer Huffman for stability; LZ77 on BWT pipeline output round-trips robustly
     constexpr uint32_t wrappedHeaderBase = 0xFFFFFFF0u;
     constexpr size_t wrapperOverhead = 4;
-
+ 
     std::vector<uint8_t> best_payload = std::move(lz77_compressed);
     uint8_t best_strategy = 0;
     size_t best_total_size = best_payload.size();
-
-    OptimizedCompressor optimized;
-    auto optimized_payload = optimized.compress(data);
+ 
+    auto optimized_payload = optimized_->compress(data);
     size_t optimized_total_size = optimized_payload.size() + wrapperOverhead;
     if (optimized_total_size < best_total_size) {
         best_total_size = optimized_total_size;
         best_payload = std::move(optimized_payload);
         best_strategy = 1;
     }
-
-    auto bwt_payload = bwt.compress(data);
+ 
+    auto bwt_payload = bwt_->compress(data);
     size_t bwt_total_size = bwt_payload.size() + wrapperOverhead;
     if (bwt_total_size < best_total_size) {
         best_total_size = bwt_total_size;
         best_payload = std::move(bwt_payload);
         best_strategy = 2;
     }
-
+ 
     if (best_strategy == 0) {
         return best_payload;
     }
-
+ 
     std::vector<uint8_t> result;
     result.reserve(best_payload.size() + wrapperOverhead);
     const uint32_t header = wrappedHeaderBase | static_cast<uint32_t>(best_strategy);
@@ -66,45 +66,42 @@ std::vector<uint8_t> UltraCompressor::compress(const std::vector<uint8_t>& data)
     result.insert(result.end(), best_payload.begin(), best_payload.end());
     return result;
 }
-
+ 
 std::vector<uint8_t> UltraCompressor::decompress(const std::vector<uint8_t>& data) const {
     if (data.empty()) {
         return {};
     }
-
+ 
     if (data.size() >= 4) {
         const uint32_t header = static_cast<uint32_t>(data[0]) |
             (static_cast<uint32_t>(data[1]) << 8) |
             (static_cast<uint32_t>(data[2]) << 16) |
             (static_cast<uint32_t>(data[3]) << 24);
-
+ 
         if ((header & 0xFFFFFFF0u) == 0xFFFFFFF0u) {
             uint8_t strategy = static_cast<uint8_t>(header & 0x0F);
             std::vector<uint8_t> payload(data.begin() + 4, data.end());
-
+ 
             switch (strategy) {
                 case 0: {
                     auto lz77_decompressed = lz77_->decompress(payload);
-                    BwtCompressor bwt;
-                    return bwt.inverseTransform(lz77_decompressed);
+                    return bwt_->inverseTransform(lz77_decompressed);
                 }
                 case 1: {
-                    OptimizedCompressor optimized;
-                    return optimized.decompress(payload);
+                    return optimized_->decompress(payload);
                 }
                 case 2: {
-                    BwtCompressor bwt;
-                    return bwt.decompress(payload);
+                    return bwt_->decompress(payload);
                 }
                 default:
                     throw std::runtime_error("Unknown Ultra compression strategy");
             }
         }
     }
-
+ 
     auto lz77_decompressed = lz77_->decompress(data);
-    BwtCompressor bwt;
-    return bwt.inverseTransform(lz77_decompressed);
+    return bwt_->inverseTransform(lz77_decompressed);
 }
-
+ 
 } // namespace compression
+


### PR DESCRIPTION
- ArithmeticCompressor::getSymbol: Replace O(256) linear scan with O(log 256) Fenwick binary lifting
  - Decompression speedup: 7MB random data reduced from ~6300ms to ~1100ms
- BwtCompressor::mtf_encode/decode: Replace erase/insert with std::rotate
  - Eliminates O(N^2) vector shifts per symbol, improves encoding speed
- UltraCompressor: Fix decompress fallback to use instance members instead of creating new instances
- Remove dead code:
  - BwtCompressor::bwt_transform_fast (declared but never defined)
  - OptimizedCompressor::analyzeData (computed but never used)
  - DataCharacteristics struct (unused after removing analyzeData)
  - write_u32_be (no longer called by BwtCompressor)

Test results: 72/72 tests pass (100%)
Compression ratios unchanged (BWT: 25.74% text, 19.43% source code)